### PR TITLE
Fix race condition

### DIFF
--- a/r.lua
+++ b/r.lua
@@ -23,7 +23,11 @@ local function findID(url)
 end
 
 local function newID()
-  return #callbackRegistry + 1
+  for i = 1, math.huge do
+    if not callbackRegistry[i] then
+      return i
+    end
+  end
 end
 
 local function trimID(url)
@@ -35,8 +39,8 @@ end
 function request(callback, url, headers, postData)
   local id = newID()
   local newUrl = url .. "#R" .. id
-  http.request(newUrl, postData, headers)
   callbackRegistry[id] = callback
+  http.request(newUrl, postData, headers)
 end
 
 function init(jua)
@@ -45,7 +49,7 @@ function init(jua)
     local id = findID(url)
     if id and callbackRegistry[id] then
       callbackRegistry[id](true, trimID(url), handle)
-      table.remove(callbackRegistry, id)
+      callbackRegistry[id] = nil
     end
   end)
 
@@ -53,7 +57,7 @@ function init(jua)
     local id = findID(url)
     if id and callbackRegistry[id] then
       callbackRegistry[id](false, trimID(url), handle)
-      table.remove(callbackRegistry, id)
+      callbackRegistry[id] = nil
     end
   end)
 end


### PR DESCRIPTION
Fixes a race condition where if two http requests are made asynchronously and the first request finishes before the second one, the callback registry would move the second callback into the first callback slot, ensuring that the second callback would never be called.